### PR TITLE
 onEventSelected event trigger fix

### DIFF
--- a/lib/flutter_neat_and_clean_calendar.dart
+++ b/lib/flutter_neat_and_clean_calendar.dart
@@ -610,6 +610,7 @@ class _CalendarState extends State<Calendar> {
                     height: widget.eventTileHeight ??
                         MediaQuery.of(context).size.height * 0.075,
                     child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
                       onTap: () {
                         if (widget.onEventSelected != null) {
                           widget.onEventSelected!(event);


### PR DESCRIPTION
onEventSelected event is now triggered if the click is in the empty space of the row. See #46 